### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Using [Vundle](https://github.com/gmarik/vundle)
 
 ```VimL
 
-    Bundle "sudar/vim-arduino-syntax"
+    Plugin "sudar/vim-arduino-syntax"
 
-    And :BundleInstall
+    And :PluginInstall
 
 ```
 Credit


### PR DESCRIPTION
Vundle no longer uses "Bundle" it is deprecated and is now called "Plugin"
Therefore:
Bundle "sudar/vim-arduino-syntax"   ---->   Plugin 'sudar/vim-arduino-syntax'
BundleInstall     ---->     PluginInstall